### PR TITLE
Removing bundle-hashlink property

### DIFF
--- a/context/v1/EU/unstable.json
+++ b/context/v1/EU/unstable.json
@@ -13,9 +13,7 @@
 
         "VaccinationCertificate": {
             "@id": "https://w3id.org/vaccination#VaccinationCertificate",
-            "bundle-hashlink" : {
-                "@type": "http://www.w3.org/2001/XMLSchema#string"
-            },
+ 
             "@context": {
                 "@version": 1.1,
                 "@protected": true,


### PR DESCRIPTION
@tplooker  Follow up from our email discussion yesterday. Removing the "bundle-hashlink" property from unstable.json. This will help avoid creating vocab term update, as this round of testing is focused on fhir mappings to ccg vaccination cert vocabulary.

We will bring this item back for review after we validate the basic fhir mappings based on jurisdiction. i.e if all goes well with this test, we can consider adding context mapping for another jurisdiction e.g. US. Once we validate the fhir mapping by jurisdiction, we can add minimal vocab addition to support basic provenance (hashlink of the fhir bundle from which the vaccine certificate was created).

